### PR TITLE
Eilara/extra args for get method

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,0 +1,8 @@
+{{$NEXT}}
+
+* Fixed a circular reference between the agent object and the Test::TCP it
+  creates internally. (Dave Rolsky)
+
+1.20111011    2014-10-11
+
+* Initial release

--- a/lib/Plack/Test/Agent.pm
+++ b/lib/Plack/Test/Agent.pm
@@ -62,11 +62,10 @@ sub execute_request
     return $res;
 }
 
-sub get
-{
-    my ($self, $uri) = @_;
-    my $req          = GET $self->normalize_uri($uri);
-    return $self->execute_request( $req );
+sub get {
+    my ( $self, $uri, @args ) = @_;
+    my $req                   = GET $self->normalize_uri($uri), @args;
+    return $self->execute_request($req);
 }
 
 sub post

--- a/lib/Plack/Test/Agent.pm
+++ b/lib/Plack/Test/Agent.pm
@@ -33,18 +33,20 @@ sub start_server
 {
     my ($self, $server_class) = @_;
 
-    my $ua     = $self->ua ? $self->ua : $self->ua( $self->get_mech );
+    my $app  = $self->app;
+    my $host = $self->host;
+
     my $server = Test::TCP->new(
         code => sub
         {
             my $port = shift;
-            $self->port( $port );
-            Plack::Loader->auto( port => $port, host => $self->host )
-                         ->run( $self->app );
+            Plack::Loader->auto( port => $port, host => $host )
+                         ->run( $app );
         },
     );
 
     $self->port( $server->port );
+    $self->ua( $self->get_mech ) unless $self->ua;
     $self->server( $server );
 }
 

--- a/t/cycle.t
+++ b/t/cycle.t
@@ -1,0 +1,32 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use Test::Requires 'Test::Memory::Cycle';
+
+use Test::More;
+use Plack::Test::Agent;
+use Test::Memory::Cycle;
+
+my $app = sub
+{
+    return [ 200, [ 'Content-Type' => 'text/plain' ], [ 'Hello World' ] ];
+};
+
+my $agent = Plack::Test::Agent->new(
+    app    => $app,
+    server => 'HTTP::Server::PSGI',
+);
+
+memory_cycle_ok(
+    $agent,
+    'no memory cycles in the Plack::Test::Agent object'
+);
+
+memory_cycle_ok(
+    $agent->get_mech,
+    'no memory cycles in object returned by Plack::Test::Agent->get_mech'
+);
+
+done_testing;

--- a/t/extra_get_args.t
+++ b/t/extra_get_args.t
@@ -1,0 +1,23 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use Test::More;
+use Plack::Test::Agent;
+
+my $app = sub
+{
+    my $content = shift->{HTTP_ACCEPT_LANGUAGE};
+    return [ 200, [], [ $content ] ];
+};
+
+my $agent = Plack::Test::Agent->new( app => $app );
+
+my $res = $agent->get( '/', 'Accept-Language' => 'en' );
+is $res->content, 'en';
+
+done_testing;
+
+
+

--- a/t/mech.t
+++ b/t/mech.t
@@ -25,8 +25,9 @@ my $app = sub
     return [ $code, [ 'Content-Type' => 'text/plain' ], [ $output ] ];
 };
 
-my $mech = Plack::Test::Agent->new( app    => $app,
-                                    server => 'HTTP::Server::PSGI' )->get_mech;
+my $agent = Plack::Test::Agent->new( app    => $app,
+                                     server => 'HTTP::Server::PSGI' );
+my $mech = $agent->get_mech;
 
 $mech->get_ok( '/?have=foo;want=foo',
     'Request should succeed when values match' );


### PR DESCRIPTION
LWP related Perl methods (e.g. WWW::Mechanize::get) always let you pass
through arguments, to be picked by the various layers along the call
flow, in a chain-of-responsibility style.

This allows you to pass custom headers, for example, no matter how many
abstractions between the caller and the final receiver. In this case,
somewhere beyond HTTP::Request.

We should do the same.
